### PR TITLE
Add interactive key pair generation flow

### DIFF
--- a/keyzerchief_app/app.py
+++ b/keyzerchief_app/app.py
@@ -14,6 +14,7 @@ from .keystore import check_unsaved_changes, find_entry_index_by_alias, get_keys
 from .keystore_actions import (
     change_keystore_password,
     delete_entry,
+    generate_key_pair,
     import_cert_file,
     import_cert_from_url,
     import_pkcs12_keypair,
@@ -159,7 +160,15 @@ def run_app(stdscr: "curses.window", argv: Sequence[str]) -> None:
         elif curses.KEY_F1 <= key <= curses.KEY_F10:
             highlight_footer_key(stdscr, key - curses.KEY_F1)
 
-            if key == curses.KEY_F3:
+            if key == curses.KEY_F2:
+                draw_ui(stdscr, state, entries, selected, scroll_offset, detail_scroll, active_panel, True)
+                alias = generate_key_pair(stdscr, state)
+                if alias:
+                    entries = get_keystore_entries(state)
+                    selected = find_entry_index_by_alias(entries, alias)
+                    check_unsaved_changes(state)
+
+            elif key == curses.KEY_F3:
                 draw_ui(stdscr, state, entries, selected, scroll_offset, detail_scroll, active_panel, True)
                 alias = import_cert_file(stdscr, state)
                 if alias:

--- a/keyzerchief_app/keystore_actions.py
+++ b/keyzerchief_app/keystore_actions.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import os
+import random
 import shutil
 import subprocess
 import tempfile
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Optional
 
@@ -18,10 +20,27 @@ from .ui.intro import fade_logo, intro_window, prompt_password, show_logo
 from .ui.popups import clear_window, file_picker, popup_form
 
 
-def handle_import_result(alias: str, result: subprocess.CompletedProcess[str], win: "curses.window") -> Optional[str]:
+def _show_error(win: "curses.window", message: str) -> None:
+    """Display ``message`` on ``win`` and wait for a key press."""
+    clear_window(win)
+    win.addstr(3, 2, message, curses.A_BOLD)
+    win.addstr(win.getmaxyx()[0] - 3, 2, "Press any key to continue.")
+    win.refresh()
+    win.getch()
+
+
+def handle_import_result(
+    alias: str,
+    result: subprocess.CompletedProcess[str],
+    win: "curses.window",
+    success_action: str = "imported",
+    extra_message: Optional[str] = None,
+) -> Optional[str]:
     win_height, win_width = win.getmaxyx()
     if result.returncode == 0:
-        win.addstr(3, 2, f"Successfully imported: {alias}", curses.A_BOLD)
+        win.addstr(3, 2, f"Successfully {success_action}: {alias}", curses.A_BOLD)
+        if extra_message:
+            win.addstr(4, 2, extra_message[: win_width - 4])
         win.addstr(win_height - 3, 2, "Press any key to continue.")
         win.refresh()
         win.getch()
@@ -153,6 +172,190 @@ def import_pkcs8_keypair(stdscr: "curses.window", state: AppState) -> Optional[s
         if os.path.exists(p12_path):
             os.remove(p12_path)
     return None
+
+
+def generate_key_pair(stdscr: "curses.window", state: AppState) -> Optional[str]:
+    """Interactively collect parameters and generate a key pair."""
+
+    if not state.keystore_path:
+        return None
+
+    while True:
+        algorithm_form, win = popup_form(
+            stdscr,
+            title="Generate Key Pair",
+            labels=["Algorithm:", "Key size:", "EC parameter set:", "Named curve:"],
+            choice_fields=[0, 2],
+            choice_labels={
+                0: ("RSA", "DSA", "EC"),
+                2: ("ANSI X9.62", "NIST", "SEC", "Edwards"),
+            },
+            dependencies={1: (0, ("RSA", "DSA")), 2: (0, ("EC",)), 3: (0, ("EC",))},
+            default_values={1: "2048", 3: "prime256v1"},
+        )
+
+        if not algorithm_form:
+            return None
+
+        algorithm = algorithm_form.get("algorithm", "RSA")
+        key_size_value = algorithm_form.get("key_size", "2048").strip()
+        named_curve = algorithm_form.get("named_curve", "prime256v1").strip() or "prime256v1"
+        win.clear()
+        win.refresh()
+
+        if algorithm in {"RSA", "DSA"}:
+            try:
+                key_size = int(key_size_value)
+                if key_size < 512:
+                    raise ValueError
+            except ValueError:
+                _show_error(win, "Key size must be a number greater than 511.")
+                continue
+        else:
+            key_size = None
+
+        break
+
+    if algorithm == "RSA":
+        signature_options = ("SHA256withRSA", "SHA384withRSA", "SHA512withRSA", "SHA1withRSA")
+    elif algorithm == "DSA":
+        signature_options = ("SHA256withDSA", "SHA1withDSA")
+    else:
+        signature_options = ("SHA256withECDSA", "SHA384withECDSA", "SHA512withECDSA")
+
+    default_start = datetime.now().date()
+    default_end = default_start + timedelta(days=365)
+    generated_serial = f"{random.getrandbits(64):X}"
+    default_alias = f"{algorithm.lower()}-{datetime.now().strftime('%Y%m%d%H%M%S')}"
+
+    while True:
+        details_form, win = popup_form(
+            stdscr,
+            title="Certificate Options",
+            labels=[
+                "Version:",
+                "Signature algorithm:",
+                "Validity start:",
+                "Validity end:",
+                "Serial number:",
+                "Alias:",
+            ],
+            choice_fields=[0, 1],
+            choice_labels={0: ("Version 1", "Version 3"), 1: signature_options},
+            default_values={
+                2: default_start.isoformat(),
+                3: default_end.isoformat(),
+                4: generated_serial,
+                5: default_alias,
+            },
+            placeholder_values={2: "YYYY-MM-DD", 3: "YYYY-MM-DD"},
+        )
+
+        if not details_form:
+            return None
+
+        version = details_form.get("version", "Version 3")
+        signature_alg = details_form.get("signature_algorithm", signature_options[0])
+        alias = details_form.get("alias", default_alias).strip()
+        start_text = details_form.get("validity_start", default_start.isoformat())
+        end_text = details_form.get("validity_end", default_end.isoformat())
+
+        try:
+            start_date = datetime.strptime(start_text, "%Y-%m-%d").date()
+            end_date = datetime.strptime(end_text, "%Y-%m-%d").date()
+        except ValueError:
+            _show_error(win, "Enter validity dates in YYYY-MM-DD format.")
+            continue
+
+        validity_days = (end_date - start_date).days
+        if validity_days <= 0:
+            _show_error(win, "Validity end must be after start date.")
+            continue
+
+        if not alias:
+            _show_error(win, "Alias cannot be empty.")
+            continue
+
+        startdate_arg = f"{start_date.strftime('%Y/%m/%d')} 00:00:00"
+        win.clear()
+        win.refresh()
+        break
+
+    name_form, win = popup_form(
+        stdscr,
+        title="Distinguished Name",
+        labels=["CN:", "OU:", "O:", "L:", "ST:", "C:"],
+    )
+
+    if not name_form:
+        return None
+
+    components = []
+    for key, prefix in (
+        ("cn", "CN"),
+        ("ou", "OU"),
+        ("o", "O"),
+        ("l", "L"),
+        ("st", "ST"),
+        ("c", "C"),
+    ):
+        value = name_form.get(key, "").strip()
+        if value:
+            components.append(f"{prefix}={value}")
+
+    if not components:
+        _show_error(win, "Provide at least one distinguished name component.")
+        return None
+
+    dname = ", ".join(components)
+    win.clear()
+    win.refresh()
+
+    cmd = [
+        "keytool",
+        "-genkeypair",
+        "-alias",
+        alias,
+        "-keyalg",
+        algorithm,
+        "-keystore",
+        str(state.keystore_path),
+        "-storepass",
+        state.keystore_password,
+        "-keypass",
+        state.keystore_password,
+        "-dname",
+        dname,
+        "-validity",
+        str(validity_days),
+        "-startdate",
+        startdate_arg,
+        "-sigalg",
+        signature_alg,
+    ]
+
+    if algorithm == "EC":
+        cmd += ["-groupname", named_curve]
+    else:
+        cmd += ["-keysize", str(key_size)]
+
+    if version == "Version 3":
+        cmd += ["-ext", "BasicConstraints:critical=ca:false"]
+
+    clear_window(win)
+    win.addstr(2, 2, "Generating key pair...", curses.A_BOLD)
+    win.refresh()
+
+    result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+
+    serial_number = details_form.get("serial_number", generated_serial)
+    return handle_import_result(
+        alias,
+        result,
+        win,
+        "generated",
+        f"Requested serial number: {serial_number}" if serial_number else None,
+    )
 
 
 def import_cert_file(stdscr: "curses.window", state: AppState) -> Optional[str]:

--- a/keyzerchief_app/ui/popups.py
+++ b/keyzerchief_app/ui/popups.py
@@ -152,8 +152,8 @@ def popup_form(
     file_fields: Optional[list[int]] = None,
     masked_fields: Optional[list[int]] = None,
     choice_fields: Optional[list[int]] = None,
-    dependencies: Optional[dict[int, tuple[int, str]]] = None,
-    choice_labels: Optional[dict[int, tuple[str, str]]] = None,
+    dependencies: Optional[dict[int, tuple[int, str | tuple[str, ...]]]] = None,
+    choice_labels: Optional[dict[int, tuple[str, ...]]] = None,
     default_values: Optional[dict[int, str]] = None,
     placeholder_values: Optional[dict[int, str]] = None,
     buttons: Optional[list[str]] = None,
@@ -197,7 +197,11 @@ def popup_form(
             dep = dependencies.get(i)
             if dep:
                 dep_idx, expected = dep
-                if values[dep_idx] != expected:
+                if isinstance(expected, (tuple, list)):
+                    expected_values = tuple(expected)
+                else:
+                    expected_values = (expected,)
+                if values[dep_idx] not in expected_values:
                     continue
 
             visible_fields.append(i)


### PR DESCRIPTION
## Summary
- add a multi-step key pair generation workflow triggered by F2
- support algorithm-specific form options with validation and distinguished name capture
- extend popup form helper to allow dependent fields on multiple values and richer choice lists

## Testing
- python -m compileall keyzerchief_app

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690df1e249c4832dbb3ad8508e927f77)