### PR TITLE
Add rolling option to popup form and use for signature algorithm

### DIFF
--- a/keyzerchief_app/keystore_actions.py
+++ b/keyzerchief_app/keystore_actions.py
@@ -249,7 +249,7 @@ def generate_key_pair(stdscr: "curses.window", state: AppState) -> Optional[str]
                 5: default_alias,
             },
             placeholder_values={2: "YYYY-MM-DD", 3: "YYYY-MM-DD"},
-            rolling=True,
+            rolling_fields=[1],
         )
 
         if not details_form:

--- a/keyzerchief_app/keystore_actions.py
+++ b/keyzerchief_app/keystore_actions.py
@@ -249,6 +249,7 @@ def generate_key_pair(stdscr: "curses.window", state: AppState) -> Optional[str]
                 5: default_alias,
             },
             placeholder_values={2: "YYYY-MM-DD", 3: "YYYY-MM-DD"},
+            rolling=True,
         )
 
         if not details_form:

--- a/keyzerchief_app/ui/popups.py
+++ b/keyzerchief_app/ui/popups.py
@@ -157,7 +157,7 @@ def popup_form(
     default_values: Optional[dict[int, str]] = None,
     placeholder_values: Optional[dict[int, str]] = None,
     buttons: Optional[list[str]] = None,
-    rolling: bool = False,
+    rolling_fields: Optional[list[int]] = None,
 ):
     """Collect user input using a vertical form."""
     height, width = stdscr.getmaxyx()
@@ -170,6 +170,7 @@ def popup_form(
     file_fields = file_fields or []
     masked_fields = masked_fields or []
     choice_fields = choice_fields or []
+    rolling_fields = set(rolling_fields or [])
     dependencies = dependencies or {}
     choice_labels = choice_labels or {i: ("Yes", "No") for i in choice_fields}
     default_values = default_values or {}
@@ -214,16 +215,10 @@ def popup_form(
                 selected_value = values[i]
                 win.addstr(y, field_start_x - len(label) + 2, label)
 
-                if rolling:
-                    display_width = win_width - field_start_x - 5
+                if i in rolling_fields:
                     attr = curses.A_REVERSE if is_selected else curses.color_pair(COLOR_PAIR_MENU)
-                    display_text = f" {selected_value} "
-                    win.addstr(
-                        y,
-                        field_start_x + 3,
-                        display_text.ljust(display_width),
-                        attr,
-                    )
+                    display_text = f"< {selected_value} >"
+                    win.addstr(y, field_start_x + 3, display_text, attr)
                 else:
                     x = field_start_x + 3
                     for opt in options:
@@ -269,7 +264,7 @@ def popup_form(
             if current in choice_fields:
                 options = choice_labels[current]
                 selected_index = options.index(values[current])
-                if rolling:
+                if current in rolling_fields:
                     x = field_start_x + 3
                 else:
                     x = field_start_x + 3 + sum(len(opt) + 3 for opt in options[:selected_index])

--- a/keyzerchief_app/ui/popups.py
+++ b/keyzerchief_app/ui/popups.py
@@ -157,6 +157,7 @@ def popup_form(
     default_values: Optional[dict[int, str]] = None,
     placeholder_values: Optional[dict[int, str]] = None,
     buttons: Optional[list[str]] = None,
+    rolling: bool = False,
 ):
     """Collect user input using a vertical form."""
     height, width = stdscr.getmaxyx()
@@ -213,16 +214,27 @@ def popup_form(
                 selected_value = values[i]
                 win.addstr(y, field_start_x - len(label) + 2, label)
 
-                x = field_start_x + 3
-                for opt in options:
-                    attr = curses.A_NORMAL
-                    if is_selected and selected_value == opt:
-                        attr |= curses.A_REVERSE
-                    elif not is_selected and selected_value == opt:
-                        attr = curses.color_pair(COLOR_PAIR_MENU)
+                if rolling:
+                    display_width = win_width - field_start_x - 5
+                    attr = curses.A_REVERSE if is_selected else curses.color_pair(COLOR_PAIR_MENU)
+                    display_text = f" {selected_value} "
+                    win.addstr(
+                        y,
+                        field_start_x + 3,
+                        display_text.ljust(display_width),
+                        attr,
+                    )
+                else:
+                    x = field_start_x + 3
+                    for opt in options:
+                        attr = curses.A_NORMAL
+                        if is_selected and selected_value == opt:
+                            attr |= curses.A_REVERSE
+                        elif not is_selected and selected_value == opt:
+                            attr = curses.color_pair(COLOR_PAIR_MENU)
 
-                    win.addstr(y, x, f" {opt} ", attr)
-                    x += len(opt) + 3
+                        win.addstr(y, x, f" {opt} ", attr)
+                        x += len(opt) + 3
             else:
                 val = values[i] if i not in masked_fields else "*" * len(values[i])
 
@@ -257,7 +269,10 @@ def popup_form(
             if current in choice_fields:
                 options = choice_labels[current]
                 selected_index = options.index(values[current])
-                x = field_start_x + 3 + sum(len(opt) + 3 for opt in options[:selected_index])
+                if rolling:
+                    x = field_start_x + 3
+                else:
+                    x = field_start_x + 3 + sum(len(opt) + 3 for opt in options[:selected_index])
                 win.move(y, x + 1)
             else:
                 val = values[current] if current not in masked_fields else "*" * len(values[current])


### PR DESCRIPTION
## Summary
- add an optional rolling display mode to popup_form choice fields so only the selected option is shown
- enable rolling mode for the signature algorithm selector when generating a key pair

## Testing
- not run (curses UI components require interactive terminal)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690df8c87de4832d94062bfc29637cee)