### PR TITLE
Attach GitHub release assets for built binaries

### DIFF
--- a/.github/workflows/build-linux-amd64.yml
+++ b/.github/workflows/build-linux-amd64.yml
@@ -1,0 +1,53 @@
+name: Build Linux (amd64) Binary
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libasound2-dev libncurses-dev
+          python -m pip install --upgrade pip
+          pip install pyinstaller
+
+      - name: Build binary
+        run: |
+          pyinstaller --onefile --name keyzerchief \
+            --add-data "sfx:sfx" \
+            keyzerchief
+
+      - name: Prepare artifact
+        run: |
+          mkdir -p artifacts
+          mv dist/keyzerchief artifacts/keyzerchief-linux-amd64
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: keyzerchief-linux-amd64
+          path: artifacts/keyzerchief-linux-amd64
+          if-no-files-found: error
+
+      - name: Publish release asset
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: artifacts/keyzerchief-linux-amd64

--- a/.github/workflows/build-macos-arm64.yml
+++ b/.github/workflows/build-macos-arm64.yml
@@ -1,0 +1,51 @@
+name: Build macOS (Apple Silicon) Binary
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: macos-14
+    permissions:
+      contents: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyinstaller
+
+      - name: Build binary
+        run: |
+          pyinstaller --onefile --name keyzerchief \
+            --add-data "sfx:sfx" \
+            keyzerchief
+
+      - name: Prepare artifact
+        run: |
+          mkdir -p artifacts
+          mv dist/keyzerchief artifacts/keyzerchief-macos-arm64
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: keyzerchief-macos-arm64
+          path: artifacts/keyzerchief-macos-arm64
+          if-no-files-found: error
+
+      - name: Publish release asset
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: artifacts/keyzerchief-macos-arm64

--- a/.github/workflows/build-windows-amd64.yml
+++ b/.github/workflows/build-windows-amd64.yml
@@ -1,0 +1,53 @@
+name: Build Windows (amd64) Binary
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyinstaller
+
+      - name: Build binary
+        shell: bash
+        run: |
+          pyinstaller --onefile --name keyzerchief \
+            --add-data "sfx;sfx" \
+            keyzerchief
+
+      - name: Prepare artifact
+        shell: bash
+        run: |
+          mkdir -p artifacts
+          mv dist/keyzerchief.exe artifacts/keyzerchief-windows-amd64.exe
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: keyzerchief-windows-amd64
+          path: artifacts/keyzerchief-windows-amd64.exe
+          if-no-files-found: error
+
+      - name: Publish release asset
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: artifacts/keyzerchief-windows-amd64.exe


### PR DESCRIPTION
## Summary
- update each platform workflow to grant contents: write permissions and publish the packaged binary to the tagged release
- retain the upload-artifact step so manually triggered runs still expose downloadable builds

## Testing
- not run (workflow only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e49665a1c832dba34b5c536652510)