### PR TITLE
Handle missing curses italic attribute

### DIFF
--- a/keyzerchief_app/ui/intro.py
+++ b/keyzerchief_app/ui/intro.py
@@ -24,6 +24,9 @@ from ..keystore import check_password
 from ..state import AppState
 
 
+ITALIC_ATTR = getattr(curses, "A_ITALIC", 0)
+
+
 ASCII_ART_BASE64 = "H4sIAAAAAAAC/+NSAIJH09phqAOG4CITuUAKOpDQRIgeFCEuNAHsynCobEdFROjowK2cXDvQ3YpVKVidAlb3dIF8jCTdC+SjSeOQnYhb18BqQUjBZBtAIgAb0FSANAIAAA=="
 
 
@@ -57,7 +60,7 @@ def intro_window(stdscr: "curses.window") -> "curses.window":
         intro_win.addstr(4, 26, title[: i + 1], curses.color_pair(COLOR_PAIR_WHITE_DIM) | curses.A_BOLD)
         intro_win.refresh()
         curses.napms(9)
-    intro_win.addstr(5, 24, "Java Keystore Manager", curses.color_pair(COLOR_PAIR_CYAN) | curses.A_ITALIC)
+    intro_win.addstr(5, 24, "Java Keystore Manager", curses.color_pair(COLOR_PAIR_CYAN) | ITALIC_ATTR)
     intro_win.addstr(14, 22, "Keystore password:")
     return intro_win
 
@@ -161,3 +164,4 @@ def prompt_password(win: "curses.window", state: AppState) -> str:
                     keypad_win.addch(0, pos - 1, "★", dim_attr)
                     keypad_win.addch(0, pos, " ", bright_attr)
                     keypad_win.refresh()
+


### PR DESCRIPTION
## Summary
- define a module-level fallback for the curses italic attribute when unavailable
- update the intro window to use the fallback so the macOS build runs without errors

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e5c49b30c832db26df73d9c2aab98)