### PR TITLE
Add illustrative README screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Keyzerchief is a terminal user interface (TUI) for exploring and managing Java k
 
 ## Table of contents
 - [Features](#features)
+- [Screenshots](#screenshots)
 - [Architecture at a glance](#architecture-at-a-glance)
 - [Prerequisites](#prerequisites)
 - [Installation](#installation)
@@ -25,6 +26,12 @@ Keyzerchief is a terminal user interface (TUI) for exploring and managing Java k
 - 🔑 **Password management** including opening password-protected keystores and changing the store password.
 - 🧹 **Housekeeping tools** such as deleting entries, saving modifications, and browsing with a built-in file picker.
 - 🔔 **Ambient audio cues** (macOS `afplay`) to celebrate key actions—optional but delightful.
+
+## Screenshots
+
+| Overview | Command menu |
+| --- | --- |
+| ![Screenshot of the dual-pane Keyzerchief interface highlighting aliases and certificate details.](docs/images/overview.svg) | ![Screenshot of the Keyzerchief command menu showing contextual keystore actions.](docs/images/context-menu.svg) |
 
 ## Architecture at a glance
 ```

--- a/docs/images/context-menu.svg
+++ b/docs/images/context-menu.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 750">
+  <defs>
+    <linearGradient id="bg" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0" stop-color="#1a1f2b" />
+      <stop offset="1" stop-color="#0f141b" />
+    </linearGradient>
+    <style>
+      .title { font: 700 34px 'Fira Code', 'Courier New', monospace; fill: #fbbf24; }
+      .menu-bar { font: 500 22px 'Fira Code', 'Courier New', monospace; fill: #cbd5f5; }
+      .menu-option { font: 400 20px 'Fira Code', 'Courier New', monospace; fill: #f9fafb; }
+      .menu-option .hint { fill: #34d399; }
+      .menu-option .danger { fill: #f87171; }
+      .pane { font: 400 18px 'Fira Code', 'Courier New', monospace; fill: #94a3b8; }
+      .footer { font: 400 18px 'Fira Code', 'Courier New', monospace; fill: #9ca3af; }
+    </style>
+  </defs>
+  <rect width="1200" height="750" fill="url(#bg)" rx="28" />
+  <rect x="60" y="60" width="1080" height="630" fill="#0b1220" stroke="#9333ea" stroke-width="3" rx="18" />
+
+  <text x="90" y="110" class="title">Keyzerchief — Command menu</text>
+  <text x="90" y="150" class="menu-bar">File   Edit   Tools   View   Help</text>
+
+  <rect x="120" y="190" width="360" height="360" fill="#1f2937" stroke="#4c1d95" stroke-width="2" rx="12" />
+  <text x="150" y="230" class="menu-option">Import certificate      <tspan class="hint">⌘I</tspan></text>
+  <text x="150" y="270" class="menu-option">Import key pair         <tspan class="hint">⌘K</tspan></text>
+  <text x="150" y="310" class="menu-option">Export selected         <tspan class="hint">⌘E</tspan></text>
+  <text x="150" y="350" class="menu-option">Change password…        <tspan class="hint">⌘P</tspan></text>
+  <text x="150" y="390" class="menu-option">Duplicate entry          <tspan class="hint">⌘D</tspan></text>
+  <text x="150" y="430" class="menu-option">Delete entry             <tspan class="danger">⌘⌫</tspan></text>
+  <text x="150" y="470" class="menu-option">Save modifications       <tspan class="hint">⌘S</tspan></text>
+  <text x="150" y="510" class="menu-option">Close keystore           <tspan class="hint">⌘W</tspan></text>
+
+  <rect x="520" y="190" width="540" height="360" fill="#111827" stroke="#4c1d95" stroke-width="2" rx="12" />
+  <text x="550" y="230" class="pane">Use the menu (F10) or click the top bar to open contextual commands.</text>
+  <text x="550" y="270" class="pane">Items display familiar shortcuts and highlight destructive actions.</text>
+  <text x="550" y="310" class="pane">All changes stay in memory until you save the keystore back to disk.</text>
+  <text x="550" y="350" class="pane">Mouse scroll wheels and left-clicks are supported in every popup.</text>
+  <text x="550" y="390" class="pane">Dismiss any dialog with Esc or choose Cancel using arrow keys.</text>
+
+  <text x="90" y="690" class="footer">Tip: Audio confirmations play via afplay on macOS when actions complete.</text>
+</svg>

--- a/docs/images/overview.svg
+++ b/docs/images/overview.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 750">
+  <defs>
+    <linearGradient id="bg" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0" stop-color="#1f2933" />
+      <stop offset="1" stop-color="#11161c" />
+    </linearGradient>
+    <style>
+      .title { font: 700 36px 'Fira Code', 'Courier New', monospace; fill: #facc15; }
+      .subtitle { font: 500 22px 'Fira Code', 'Courier New', monospace; fill: #9ca3af; }
+      .pane-title { font: 600 24px 'Fira Code', 'Courier New', monospace; fill: #34d399; }
+      .pane-item { font: 400 20px 'Fira Code', 'Courier New', monospace; fill: #e5e7eb; }
+      .pane-item.expired { fill: #f87171; }
+      .detail-label { font: 600 20px 'Fira Code', 'Courier New', monospace; fill: #93c5fd; }
+      .detail-value { font: 400 20px 'Fira Code', 'Courier New', monospace; fill: #f9fafb; }
+      .badge { font: 600 18px 'Fira Code', 'Courier New', monospace; fill: #0ea5e9; }
+      .footer { font: 400 18px 'Fira Code', 'Courier New', monospace; fill: #9ca3af; }
+    </style>
+  </defs>
+  <rect width="1200" height="750" fill="url(#bg)" rx="28" />
+  <rect x="60" y="60" width="1080" height="630" fill="#0b1220" stroke="#2563eb" stroke-width="3" rx="18" />
+  <rect x="80" y="120" width="420" height="520" fill="#111827" stroke="#1f2937" stroke-width="2" rx="12" />
+  <rect x="520" y="120" width="600" height="520" fill="#111827" stroke="#1f2937" stroke-width="2" rx="12" />
+
+  <text x="90" y="110" class="title">Keyzerchief — Demo Keystore</text>
+  <text x="90" y="160" class="pane-title">Aliases ▸</text>
+  <text x="110" y="200" class="pane-item">api-service</text>
+  <text x="110" y="240" class="pane-item">internal-ca</text>
+  <text x="110" y="280" class="pane-item expired">legacy-gateway  ⏰</text>
+  <text x="110" y="320" class="pane-item">partner-edge</text>
+  <text x="110" y="360" class="pane-item">saml-idp</text>
+  <text x="110" y="400" class="pane-item">tls-frontend</text>
+  <text x="110" y="440" class="pane-item">vault-replica</text>
+  <text x="110" y="520" class="subtitle">Filter ▸ /  ·  Jump ▸ t / b  ·  Menu ▸ F10</text>
+
+  <text x="540" y="160" class="pane-title">Certificate details</text>
+  <text x="540" y="210" class="detail-label">Subject:</text>
+  <text x="720" y="210" class="detail-value">CN=api.service.local</text>
+  <text x="540" y="250" class="detail-label">Issuer:</text>
+  <text x="720" y="250" class="detail-value">CN=Keyzerchief CA</text>
+  <text x="540" y="290" class="detail-label">Valid until:</text>
+  <text x="720" y="290" class="detail-value">Jun 14 2026 14:32:00 GMT</text>
+  <text x="540" y="330" class="detail-label">Signature:</text>
+  <text x="720" y="330" class="detail-value">SHA256withRSA</text>
+  <text x="540" y="370" class="detail-label">Fingerprints:</text>
+  <text x="720" y="370" class="detail-value">SHA1 · 2F:0B:7C:…</text>
+  <text x="720" y="410" class="detail-value">SHA256 · DF:19:8A:…</text>
+  <text x="540" y="470" class="badge">✔  Verified with chain</text>
+  <text x="540" y="510" class="badge">🔒  Private key present</text>
+
+  <text x="90" y="690" class="footer">Ctrl+M toggle mouse · Ctrl+F search details · Ctrl+C quit</text>
+</svg>


### PR DESCRIPTION
## Summary
- add a screenshots section to the README for quick visual context
- include two SVG illustrations that capture the main layout and command menu

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f09183854832d82b1ff2d6cbff84e)