### PR TITLE
Add shift shortcut layer for footer

### DIFF
--- a/keyzerchief_app/app.py
+++ b/keyzerchief_app/app.py
@@ -8,7 +8,14 @@ from types import SimpleNamespace
 from typing import Sequence
 
 from .audio import play_sfx
-from .constants import LEFT_PANEL, MENU_ITEMS, MENU_SPACING, RIGHT_PANEL
+from .constants import (
+    FOOTER_OPTIONS,
+    LEFT_PANEL,
+    MENU_ITEMS,
+    MENU_SPACING,
+    RIGHT_PANEL,
+    SHIFT_FOOTER_OPTIONS,
+)
 from .curses_setup import init_curses
 from .keystore import check_unsaved_changes, find_entry_index_by_alias, get_keystore_entries, save_changes
 from .keystore_actions import (
@@ -21,6 +28,7 @@ from .keystore_actions import (
     import_pkcs8_keypair,
     open_keystore,
 )
+from .input_listener import start_modifier_monitor, stop_modifier_monitor
 from .menu import menu_modal
 from .state import AppState
 from .ui.layout import draw_footer, draw_menu_bar, draw_ui, highlight_footer_key
@@ -31,6 +39,7 @@ def run_app(stdscr: "curses.window", argv: Sequence[str]) -> None:
     """Entry point for the curses application."""
     state = AppState()
     init_curses()
+    stdscr.timeout(100)
     signal.signal(signal.SIGINT, signal.SIG_IGN)
 
     keystore_arg = argv[0] if argv else None
@@ -46,197 +55,315 @@ def run_app(stdscr: "curses.window", argv: Sequence[str]) -> None:
     open_keystore(stdscr, state, keystore_arg)
 
     entries = get_keystore_entries(state)
+    modifier_monitor = start_modifier_monitor()
 
-    while True:
-        height, width = stdscr.getmaxyx()
-        panel_height = height - 4
-        if state.reload_entries:
-            state.reload_entries = False
-            entries = get_keystore_entries(state)
-            selected = 0
-            scroll_offset = 0
-            detail_scroll = 0
+    try:
+        while True:
+            height, width = stdscr.getmaxyx()
+            shift_active = modifier_monitor.is_shift_pressed()
+            footer_options = SHIFT_FOOTER_OPTIONS if shift_active else FOOTER_OPTIONS
+            panel_height = height - 4
+            if state.reload_entries:
+                state.reload_entries = False
+                entries = get_keystore_entries(state)
+                selected = 0
+                scroll_offset = 0
+                detail_scroll = 0
 
-        draw_ui(stdscr, state, entries, selected, scroll_offset, detail_scroll, active_panel)
-        draw_footer(stdscr, state)
-        draw_menu_bar(None, width)
+            draw_ui(stdscr, state, entries, selected, scroll_offset, detail_scroll, active_panel)
+            draw_footer(stdscr, state, footer_options)
+            draw_menu_bar(None, width)
 
-        key = stdscr.getch()
+            key = stdscr.getch()
 
-        if key == curses.KEY_MOUSE and state.mouse_enabled:
-            try:
-                _, mx, my, _, mouse_event = curses.getmouse()
+            if key == -1:
+                continue
 
-                if my == 0:
-                    x = 1
-                    for i, item in enumerate(MENU_ITEMS):
-                        item_len = len(f" {item} ")
-                        if x <= mx < x + item_len:
-                            active_menu = i
-                            draw_ui(stdscr, state, entries, selected, scroll_offset, detail_scroll, active_panel, True)
-                            menu_modal(
-                                stdscr,
-                                state,
-                                active_menu,
-                                redraw_main_ui=lambda: draw_ui(
-                                    stdscr, state, entries, selected, scroll_offset, detail_scroll, active_panel, True
-                                ),
-                            )
-                            break
-                        x += item_len + MENU_SPACING
+            if key == curses.KEY_MOUSE and state.mouse_enabled:
+                try:
+                    _, mx, my, _, mouse_event = curses.getmouse()
 
-                if my == 1 and width // 2 - 6 <= mx < width // 2:
-                    selected = 0
-                    scroll_offset = 0
-                elif my == height - 2 and width // 2 - 6 <= mx < width // 2:
-                    selected = len(entries) - 1
-                    scroll_offset = max(0, len(entries) - panel_height)
+                    if my == 0:
+                        x = 1
+                        for i, item in enumerate(MENU_ITEMS):
+                            item_len = len(f" {item} ")
+                            if x <= mx < x + item_len:
+                                active_menu = i
+                                draw_ui(
+                                    stdscr,
+                                    state,
+                                    entries,
+                                    selected,
+                                    scroll_offset,
+                                    detail_scroll,
+                                    active_panel,
+                                    True,
+                                )
+                                menu_modal(
+                                    stdscr,
+                                    state,
+                                    active_menu,
+                                    redraw_main_ui=lambda: draw_ui(
+                                        stdscr,
+                                        state,
+                                        entries,
+                                        selected,
+                                        scroll_offset,
+                                        detail_scroll,
+                                        active_panel,
+                                        True,
+                                    ),
+                                )
+                                break
+                            x += item_len + MENU_SPACING
 
-                if 1 < my < height - 2:
-                    if 0 < mx < width // 2:
-                        active_panel = LEFT_PANEL
-                    elif mx >= width // 2:
-                        active_panel = RIGHT_PANEL
+                    if my == 1 and width // 2 - 6 <= mx < width // 2:
+                        selected = 0
+                        scroll_offset = 0
+                    elif my == height - 2 and width // 2 - 6 <= mx < width // 2:
+                        selected = len(entries) - 1
+                        scroll_offset = max(0, len(entries) - panel_height)
 
-                if mouse_event & 0x80000:
-                    if active_panel == LEFT_PANEL and selected > 0:
+                    if 1 < my < height - 2:
+                        if 0 < mx < width // 2:
+                            active_panel = LEFT_PANEL
+                        elif mx >= width // 2:
+                            active_panel = RIGHT_PANEL
+
+                    if mouse_event & 0x80000:
+                        if active_panel == LEFT_PANEL and selected > 0:
+                            selected -= 1
+                            if selected < scroll_offset:
+                                scroll_offset -= 1
+                            detail_scroll = 0
+                        elif active_panel == RIGHT_PANEL and detail_scroll > 0:
+                            detail_scroll -= 1
+
+                    elif mouse_event & 0x8000000:
+                        if active_panel == LEFT_PANEL and selected < len(entries) - 1:
+                            selected += 1
+                            if selected >= scroll_offset + panel_height:
+                                scroll_offset += 1
+                            detail_scroll = 0
+                        elif active_panel == RIGHT_PANEL:
+                            detail_scroll += 1
+                except curses.error:
+                    pass
+                continue
+
+            if key == curses.KEY_UP:
+                if active_panel == LEFT_PANEL:
+                    if selected > 0:
                         selected -= 1
                         if selected < scroll_offset:
                             scroll_offset -= 1
-                        detail_scroll = 0
-                    elif active_panel == RIGHT_PANEL and detail_scroll > 0:
-                        detail_scroll -= 1
+                    detail_scroll = 0
+                elif active_panel == RIGHT_PANEL and detail_scroll > 0:
+                    detail_scroll -= 1
 
-                elif mouse_event & 0x8000000:
-                    if active_panel == LEFT_PANEL and selected < len(entries) - 1:
+            elif key == curses.KEY_DOWN:
+                if active_panel == LEFT_PANEL:
+                    if selected < len(entries) - 1:
                         selected += 1
                         if selected >= scroll_offset + panel_height:
                             scroll_offset += 1
-                        detail_scroll = 0
-                    elif active_panel == RIGHT_PANEL:
-                        detail_scroll += 1
-            except curses.error:
-                pass
-            continue
+                    detail_scroll = 0
+                elif active_panel == RIGHT_PANEL:
+                    detail_scroll += 1
 
-        if key == curses.KEY_UP:
-            if active_panel == LEFT_PANEL:
-                if selected > 0:
-                    selected -= 1
-                    if selected < scroll_offset:
-                        scroll_offset -= 1
-                detail_scroll = 0
-            elif active_panel == RIGHT_PANEL and detail_scroll > 0:
-                detail_scroll -= 1
-
-        elif key == curses.KEY_DOWN:
-            if active_panel == LEFT_PANEL:
-                if selected < len(entries) - 1:
-                    selected += 1
-                    if selected >= scroll_offset + panel_height:
-                        scroll_offset += 1
-                detail_scroll = 0
-            elif active_panel == RIGHT_PANEL:
-                detail_scroll += 1
-
-        elif key == ord("t"):
-            if active_panel == LEFT_PANEL:
-                selected = 0
-                scroll_offset = 0
-            else:
-                detail_scroll = 0
-
-        elif key == ord("b"):
-            if active_panel == LEFT_PANEL:
-                selected = len(entries) - 1
-                scroll_offset = max(0, len(entries) - panel_height)
-            else:
-                detail_scroll = max(0, len(entries[selected].get("__rendered__", [])) - 1)
-
-        elif key in (ord("\t"), 9):
-            play_sfx("swipe")
-            active_panel = RIGHT_PANEL if active_panel == LEFT_PANEL else LEFT_PANEL
-
-        elif curses.KEY_F1 <= key <= curses.KEY_F10:
-            highlight_footer_key(stdscr, key - curses.KEY_F1)
-
-            if key == curses.KEY_F1:
-                draw_ui(stdscr, state, entries, selected, scroll_offset, detail_scroll, active_panel, True)
-                show_help_popup(stdscr)
-
-            elif key == curses.KEY_F2:
-                draw_ui(stdscr, state, entries, selected, scroll_offset, detail_scroll, active_panel, True)
-                alias = generate_key_pair(stdscr, state)
-                if alias:
-                    entries = get_keystore_entries(state)
-                    selected = find_entry_index_by_alias(entries, alias)
-                    check_unsaved_changes(state)
-
-            elif key == curses.KEY_F3:
-                draw_ui(stdscr, state, entries, selected, scroll_offset, detail_scroll, active_panel, True)
-                alias = import_cert_file(stdscr, state)
-                if alias:
-                    entries = get_keystore_entries(state)
-                    selected = find_entry_index_by_alias(entries, alias)
-                    check_unsaved_changes(state)
-
-            elif key == curses.KEY_F4:
-                draw_ui(stdscr, state, entries, selected, scroll_offset, detail_scroll, active_panel, True)
-                choice = prompt_import_key_type(stdscr)
-                if choice == "PKCS #12":
-                    alias = import_pkcs12_keypair(stdscr, state)
-                elif choice == "PKCS #8":
-                    alias = import_pkcs8_keypair(stdscr, state)
+            elif key == ord("t"):
+                if active_panel == LEFT_PANEL:
+                    selected = 0
+                    scroll_offset = 0
                 else:
-                    alias = None
-                if alias:
-                    entries = get_keystore_entries(state)
-                    selected = find_entry_index_by_alias(entries, alias)
+                    detail_scroll = 0
+
+            elif key == ord("b"):
+                if active_panel == LEFT_PANEL:
+                    selected = len(entries) - 1
+                    scroll_offset = max(0, len(entries) - panel_height)
+                else:
+                    detail_scroll = max(0, len(entries[selected].get("__rendered__", [])) - 1)
+
+            elif key in (ord("\t"), 9):
+                play_sfx("swipe")
+                active_panel = RIGHT_PANEL if active_panel == LEFT_PANEL else LEFT_PANEL
+
+            elif curses.KEY_F1 <= key <= curses.KEY_F10:
+                shift_active = modifier_monitor.is_shift_pressed()
+                footer_options = SHIFT_FOOTER_OPTIONS if shift_active else FOOTER_OPTIONS
+                highlight_footer_key(stdscr, key - curses.KEY_F1, footer_options)
+
+                if shift_active:
+                    continue
+
+                if key == curses.KEY_F1:
+                    draw_ui(
+                        stdscr,
+                        state,
+                        entries,
+                        selected,
+                        scroll_offset,
+                        detail_scroll,
+                        active_panel,
+                        True,
+                    )
+                    show_help_popup(stdscr)
+
+                elif key == curses.KEY_F2:
+                    draw_ui(
+                        stdscr,
+                        state,
+                        entries,
+                        selected,
+                        scroll_offset,
+                        detail_scroll,
+                        active_panel,
+                        True,
+                    )
+                    alias = generate_key_pair(stdscr, state)
+                    if alias:
+                        entries = get_keystore_entries(state)
+                        selected = find_entry_index_by_alias(entries, alias)
+                        check_unsaved_changes(state)
+
+                elif key == curses.KEY_F3:
+                    draw_ui(
+                        stdscr,
+                        state,
+                        entries,
+                        selected,
+                        scroll_offset,
+                        detail_scroll,
+                        active_panel,
+                        True,
+                    )
+                    alias = import_cert_file(stdscr, state)
+                    if alias:
+                        entries = get_keystore_entries(state)
+                        selected = find_entry_index_by_alias(entries, alias)
+                        check_unsaved_changes(state)
+
+                elif key == curses.KEY_F4:
+                    draw_ui(
+                        stdscr,
+                        state,
+                        entries,
+                        selected,
+                        scroll_offset,
+                        detail_scroll,
+                        active_panel,
+                        True,
+                    )
+                    choice = prompt_import_key_type(stdscr)
+                    if choice == "PKCS #12":
+                        alias = import_pkcs12_keypair(stdscr, state)
+                    elif choice == "PKCS #8":
+                        alias = import_pkcs8_keypair(stdscr, state)
+                    else:
+                        alias = None
+                    if alias:
+                        entries = get_keystore_entries(state)
+                        selected = find_entry_index_by_alias(entries, alias)
+                        check_unsaved_changes(state)
+
+                elif key == curses.KEY_F5:
+                    draw_ui(
+                        stdscr,
+                        state,
+                        entries,
+                        selected,
+                        scroll_offset,
+                        detail_scroll,
+                        active_panel,
+                        True,
+                    )
+                    alias = import_cert_from_url(stdscr, state)
+                    if alias:
+                        entries = get_keystore_entries(state)
+                        selected = find_entry_index_by_alias(entries, alias)
+                        check_unsaved_changes(state)
+
+                elif key == curses.KEY_F6:
+                    draw_ui(
+                        stdscr,
+                        state,
+                        entries,
+                        selected,
+                        scroll_offset,
+                        detail_scroll,
+                        active_panel,
+                        True,
+                    )
+                    change_keystore_password(stdscr, state)
                     check_unsaved_changes(state)
 
-            elif key == curses.KEY_F5:
-                draw_ui(stdscr, state, entries, selected, scroll_offset, detail_scroll, active_panel, True)
-                alias = import_cert_from_url(stdscr, state)
-                if alias:
-                    entries = get_keystore_entries(state)
-                    selected = find_entry_index_by_alias(entries, alias)
-                    check_unsaved_changes(state)
+                elif key == curses.KEY_F7:
+                    draw_ui(
+                        stdscr,
+                        state,
+                        entries,
+                        selected,
+                        scroll_offset,
+                        detail_scroll,
+                        active_panel,
+                        True,
+                    )
+                    save_changes(stdscr, state)
 
-            elif key == curses.KEY_F6:
-                draw_ui(stdscr, state, entries, selected, scroll_offset, detail_scroll, active_panel, True)
-                change_keystore_password(stdscr, state)
-                check_unsaved_changes(state)
+                elif key == curses.KEY_F8:
+                    draw_ui(
+                        stdscr,
+                        state,
+                        entries,
+                        selected,
+                        scroll_offset,
+                        detail_scroll,
+                        active_panel,
+                        True,
+                    )
+                    if delete_entry(entries[selected].get("Alias name"), stdscr, state):
+                        entries = get_keystore_entries(state)
+                        selected = min(selected, len(entries) - 1)
 
-            elif key == curses.KEY_F7:
-                draw_ui(stdscr, state, entries, selected, scroll_offset, detail_scroll, active_panel, True)
-                save_changes(stdscr, state)
+                elif key == curses.KEY_F9:
+                    draw_ui(
+                        stdscr,
+                        state,
+                        entries,
+                        selected,
+                        scroll_offset,
+                        detail_scroll,
+                        active_panel,
+                        True,
+                    )
+                    menu_modal(
+                        stdscr,
+                        state,
+                        0,
+                        redraw_main_ui=lambda: draw_ui(
+                            stdscr,
+                            state,
+                            entries,
+                            selected,
+                            scroll_offset,
+                            detail_scroll,
+                            active_panel,
+                            True,
+                        ),
+                    )
 
-            elif key == curses.KEY_F8:
-                draw_ui(stdscr, state, entries, selected, scroll_offset, detail_scroll, active_panel, True)
-                if delete_entry(entries[selected].get("Alias name"), stdscr, state):
-                    entries = get_keystore_entries(state)
-                    selected = min(selected, len(entries) - 1)
+                elif key == curses.KEY_F10:
+                    result = save_changes(stdscr, state)
+                    if result is None:
+                        break
 
-            elif key == curses.KEY_F9:
-                draw_ui(stdscr, state, entries, selected, scroll_offset, detail_scroll, active_panel, True)
-                menu_modal(
-                    stdscr,
-                    state,
-                    0,
-                    redraw_main_ui=lambda: draw_ui(
-                        stdscr, state, entries, selected, scroll_offset, detail_scroll, active_panel, True
-                    ),
-                )
-
-            elif key == curses.KEY_F10:
-                result = save_changes(stdscr, state)
-                if result is None:
+            elif key in [ord("q"), ord("Q"), 27]:
+                ret = save_changes(stdscr, state)
+                if ret is None:
                     break
 
-        elif key in [ord("q"), ord("Q"), 27]:
-            ret = save_changes(stdscr, state)
-            if ret is None:
-                break
-
-        if state.has_unsaved_changes and selected == len(entries) - 1:
-            scroll_offset = max(0, len(entries) - panel_height)
+            if state.has_unsaved_changes and selected == len(entries) - 1:
+                scroll_offset = max(0, len(entries) - panel_height)
+    finally:
+        stop_modifier_monitor()

--- a/keyzerchief_app/constants.py
+++ b/keyzerchief_app/constants.py
@@ -55,7 +55,7 @@ SHIFT_FOOTER_OPTIONS = [
     " 3ShrtCut3",
     " 4ShrtCut4",
     " 5ShrtCut5",
-    " 6ShrtCut6",
+    " 6Rename",
     " 7ShrtCut7",
     " 8ShrtCut8",
     " 9ShrtCut9",

--- a/keyzerchief_app/constants.py
+++ b/keyzerchief_app/constants.py
@@ -49,5 +49,18 @@ FOOTER_OPTIONS = [
     "10Quit",
 ]
 
+SHIFT_FOOTER_OPTIONS = [
+    " 1ShrtCut1",
+    " 2ShrtCut2",
+    " 3ShrtCut3",
+    " 4ShrtCut4",
+    " 5ShrtCut5",
+    " 6ShrtCut6",
+    " 7ShrtCut7",
+    " 8ShrtCut8",
+    " 9ShrtCut9",
+    "10ShrtCut10",
+]
+
 # Application directories
 BASE_DIR = Path(__file__).resolve().parent.parent

--- a/keyzerchief_app/input_listener.py
+++ b/keyzerchief_app/input_listener.py
@@ -1,0 +1,78 @@
+"""Background listener for modifier keys that curses cannot detect."""
+
+from __future__ import annotations
+
+import threading
+from typing import Iterable
+
+from pynput import keyboard
+
+
+class ModifierKeyMonitor:
+    """Track the state of modifier keys using a background listener."""
+
+    _SHIFT_KEYS: tuple[keyboard.Key, ...] = (
+        keyboard.Key.shift,
+        keyboard.Key.shift_l,
+        keyboard.Key.shift_r,
+    )
+
+    def __init__(self) -> None:
+        self._pressed_keys: set[keyboard.Key | keyboard.KeyCode] = set()
+        self._lock = threading.Lock()
+        self._listener: keyboard.Listener | None = None
+
+    def start(self) -> None:
+        """Start the pynput listener if it isn't already running."""
+
+        if self._listener is not None:
+            return
+
+        self._listener = keyboard.Listener(
+            on_press=self._on_press,
+            on_release=self._on_release,
+        )
+        self._listener.daemon = True
+        self._listener.start()
+
+    def stop(self) -> None:
+        """Stop the listener and reset captured state."""
+
+        if self._listener is not None:
+            self._listener.stop()
+            self._listener = None
+        with self._lock:
+            self._pressed_keys.clear()
+
+    def _on_press(self, key: keyboard.Key | keyboard.KeyCode) -> None:
+        with self._lock:
+            self._pressed_keys.add(key)
+
+    def _on_release(self, key: keyboard.Key | keyboard.KeyCode) -> None:
+        with self._lock:
+            self._pressed_keys.discard(key)
+
+    def _any_pressed(self, keys: Iterable[keyboard.Key]) -> bool:
+        with self._lock:
+            return any(key in self._pressed_keys for key in keys)
+
+    def is_shift_pressed(self) -> bool:
+        """Return ``True`` when any shift key is pressed."""
+
+        return self._any_pressed(self._SHIFT_KEYS)
+
+
+_MONITOR = ModifierKeyMonitor()
+
+
+def start_modifier_monitor() -> ModifierKeyMonitor:
+    """Ensure the global modifier monitor is running and return it."""
+
+    _MONITOR.start()
+    return _MONITOR
+
+
+def stop_modifier_monitor() -> None:
+    """Stop the global modifier monitor."""
+
+    _MONITOR.stop()

--- a/keyzerchief_app/ui/layout.py
+++ b/keyzerchief_app/ui/layout.py
@@ -23,7 +23,6 @@ from ..constants import (
     COLOR_PAIR_SELECTED_DIM_MORE,
     COLOR_PAIR_WHITE,
     COLOR_PAIR_WHITE_DIM,
-    FOOTER_OPTIONS,
     LEFT_PANEL,
     MENU_ITEMS,
     MENU_SPACING,
@@ -32,11 +31,13 @@ from ..constants import (
 from ..state import AppState
 
 
-def draw_footer(stdscr: "curses.window", state: AppState) -> None:
+def draw_footer(
+    stdscr: "curses.window", state: AppState, options: list[str]
+) -> None:
     """Render the footer with contextual shortcuts."""
     height, width = stdscr.getmaxyx()
-    spacing = width // len(FOOTER_OPTIONS)
-    for i, item in enumerate(FOOTER_OPTIONS):
+    spacing = width // len(options)
+    for i, item in enumerate(options):
         label = item[2:]
         prefix = item[:2]
         attr_key = (
@@ -48,11 +49,13 @@ def draw_footer(stdscr: "curses.window", state: AppState) -> None:
         stdscr.addstr(height - 1, i * spacing + 2, label.ljust(spacing - 2), curses.color_pair(COLOR_PAIR_HEADER))
 
 
-def highlight_footer_key(stdscr: "curses.window", key_index: int) -> None:
+def highlight_footer_key(
+    stdscr: "curses.window", key_index: int, options: list[str]
+) -> None:
     """Briefly highlight a footer label when its key is pressed."""
     height, width = stdscr.getmaxyx()
-    spacing = width // len(FOOTER_OPTIONS)
-    label = FOOTER_OPTIONS[key_index][2:]
+    spacing = width // len(options)
+    label = options[key_index][2:]
     stdscr.addstr(
         height - 1,
         key_index * spacing + 2,


### PR DESCRIPTION
## Summary
- add a background modifier listener using pynput to expose shift state to the TUI
- swap the footer shortcut labels when shift is held and prevent default actions when using the alternate layer
- refresh footer rendering/highlighting logic to work with dynamic shortcut sets

## Testing
- python -m compileall keyzerchief_app

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69107d056774832d88ac7288aa18fcd2)