### PR TITLE
Add icons for keystore entry types in list view

### DIFF
--- a/keyzerchief_app/keystore.py
+++ b/keyzerchief_app/keystore.py
@@ -138,9 +138,17 @@ def get_keystore_entries(state: AppState) -> list[dict]:
         entries.append(current_entry)
 
     for entry in entries:
-        entry_type = entry.get("Entry type", "").lower()
-        entry["__is_key__"] = "key" in entry_type
-        entry["__is_cert__"] = "cert" in entry_type or "trustedcert" in entry_type
+        entry_type = entry.get("Entry type", "")
+        entry_type_lower = entry_type.lower()
+        entry["__is_key__"] = "key" in entry_type_lower
+        entry["__is_cert__"] = "cert" in entry_type_lower or "trustedcert" in entry_type_lower
+
+        if "trustedcertentry" in entry_type_lower:
+            entry["__icon__"] = "🎖"
+        elif "privatekeyentry" in entry_type_lower:
+            entry["__icon__"] = "🔑"
+        else:
+            entry["__icon__"] = ""
 
         detail_lines: list[tuple[str, str]] = []
         priority = ["Alias name", "Entry type", "Creation date", "Valid from"]

--- a/keyzerchief_app/keystore.py
+++ b/keyzerchief_app/keystore.py
@@ -144,11 +144,11 @@ def get_keystore_entries(state: AppState) -> list[dict]:
         entry["__is_cert__"] = "cert" in entry_type_lower or "trustedcert" in entry_type_lower
 
         if "trustedcertentry" in entry_type_lower:
-            entry["__icon__"] = "🎖"
+            entry["__icon__"] = "⬔"
         elif "privatekeyentry" in entry_type_lower:
-            entry["__icon__"] = "🔑"
+            entry["__icon__"] = "⬚"
         else:
-            entry["__icon__"] = ""
+            entry["__icon__"] = "☠"
 
         detail_lines: list[tuple[str, str]] = []
         priority = ["Alias name", "Entry type", "Creation date", "Valid from"]

--- a/keyzerchief_app/ui/layout.py
+++ b/keyzerchief_app/ui/layout.py
@@ -147,6 +147,11 @@ def draw_ui(
     for i in range(scroll_offset, min(len(entries), scroll_offset + visible_height)):
         y_pos = 2 + i - scroll_offset
         alias = entries[i].get("Alias name", "<unknown>")
+        icon = entries[i].get("__icon__", "")
+        if icon:
+            display_text = f"{icon} {alias}".strip()
+        else:
+            display_text = alias
         is_expired = entries[i].get("__expired__", False)
         if active_panel == LEFT_PANEL:
             if i == selected:
@@ -167,7 +172,7 @@ def draw_ui(
             attr |= curses.A_DIM
 
         stdscr.addstr(y_pos, 2, " " * (panel_width - 4))
-        stdscr.addstr(y_pos, 2, alias[: panel_width - 4], attr)
+        stdscr.addstr(y_pos, 2, display_text[: panel_width - 4], attr)
 
     for y in range(2 + len(entries) - scroll_offset, height - 2):
         stdscr.addstr(y, 2, " " * (panel_width - 4))


### PR DESCRIPTION
## Summary
- assign display icons for trusted certificate and private key entries when parsing keystore data
- prepend the appropriate icon to each entry in the left panel list view

## Testing
- not run (UI change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691145b417b8832db6b12f912e3e190a)